### PR TITLE
fix: missing lang attribute

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
 
     <!-- proper charset -->


### PR DESCRIPTION
Fix lighthouse result: <html> element does not have a [lang] attribute


