### PR TITLE
fix: user-scalable

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -6,7 +6,7 @@
     <!-- proper charset -->
     <meta charset="utf-8">
     <!-- Disable mobile scaling -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
     <title>Nicolas Mattia$if(title)$ &ndash; $title$ $endif$</title>
 
@@ -18,7 +18,7 @@
     <!-- comes from favicon generator -->
 
     <!-- OG tags -->
-    $if(title)$<meta property="og:title" content="$title$" />$endif$
+    $if(title)$<meta property="og:title" content="$title$" />$endifv
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://nmattia.com$url$" />
     $if(og_image)$<meta property="og:image" content="https://nmattia.com$og_image$" />$endif$

--- a/templates/default.html
+++ b/templates/default.html
@@ -18,7 +18,7 @@
     <!-- comes from favicon generator -->
 
     <!-- OG tags -->
-    $if(title)$<meta property="og:title" content="$title$" />$endifv
+    $if(title)$<meta property="og:title" content="$title$" />$endif$
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://nmattia.com$url$" />
     $if(og_image)$<meta property="og:image" content="https://nmattia.com$og_image$" />$endif$


### PR DESCRIPTION
Fix lighthouse result: [user-scalable="no"] is used in the <meta name="viewport"> element or the [maximum-scale] attribute is less than 5.

P.S.: Even though it is not stricto sensu wrong, lighthouse is known to complain about it


