### PR TITLE
fix: missing description

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -10,6 +10,8 @@
 
     <title>Nicolas Mattia$if(title)$ &ndash; $title$ $endif$</title>
 
+    <meta name="description" content="Software Engineer based in Zurich who has a thing for functional programming, reproducible builds and infrastructure as code">
+
     <!-- the "hash=..." is replace with the hash of the CSS file -->
     <link rel="stylesheet" type="text/css" href="/styles/default.css?hash=XXX_CSS" />
     <link rel="alternate" type="application/atom+xml" title="nmattia Atom feed" href="/atom.xml?type=blog" />


### PR DESCRIPTION
Fix lighthouse result: Document does not have a meta description


